### PR TITLE
fix: arregla punto y coma despues de require_once

### DIFF
--- a/index.php
+++ b/index.php
@@ -1,7 +1,6 @@
 <?php
-require_once "functions.php"   // ❌ ERROR 1: Falta punto y coma
+require_once "functions.php";
 
-// Ejecutar procedimiento almacenado (corregido)
 $conn->query("CALL UpdateExpiredPayments()");
 
 // Llamadas correctas


### PR DESCRIPTION
Se corrige un error de sintaxis que impedía la ejecución del archivo index.php.
El issue queda solucionado.

Fixes #5